### PR TITLE
Add a number guessing game with 10 attempts and feedback

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,53 @@
 package main
 
-import "fmt"
+import (
+	"bufio"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"strconv"
+	"strings"
+)
 
 func main() {
-	fmt.Println("Hello, World!")
+	fmt.Println("Welcome to the Guessing Game!")
+	fmt.Println("An aleatory number will be generated between 1 and 100, try to guess it!")
+	fmt.Println("You have 10 attempts to guess the number.")
+
+	scanner := bufio.NewScanner(os.Stdin)
+	chutes := [10]int64{}
+	x := rand.Int64N(101)
+
+	for i := range chutes {
+		fmt.Println("Enter your guess:")
+		scanner.Scan()
+		chute := scanner.Text()
+		chute = strings.TrimSpace(chute)
+
+		chuteInt, err := strconv.ParseInt(chute, 10, 64)
+		if err != nil {
+			fmt.Println("Invalid input, please enter a number.")
+			return
+		}
+
+		switch {
+		case chuteInt < x:
+			fmt.Println("Your guess is too low.", chuteInt)
+		case chuteInt > x:
+			fmt.Println("Your guess is too high.", chuteInt)
+		case chuteInt == x:
+			fmt.Println("Congratulations! You guessed the number!", chuteInt)
+			return
+		}
+
+		chutes[i] = chuteInt
+	}
+
+	fmt.Printf(
+		"Sorry, you didn't guess the number, which was %d\n"+
+			"You had 10 attempts\n"+
+			"These were your attempts: %v\n",
+		x, chutes,
+	)
+
 }

--- a/mypackage/a.go
+++ b/mypackage/a.go
@@ -1,0 +1,14 @@
+package mypackage
+
+import (
+	"fmt"
+
+	"github.com/ViniAguiar1/rocket-go-course/mypackage/internal/foo"
+)
+
+var Age int = 10
+
+func GetMyName() string {
+	fmt.Println(foo.MyName)
+	return foo.MyName
+}

--- a/mypackage/internal/foo/foo.go
+++ b/mypackage/internal/foo/foo.go
@@ -1,0 +1,3 @@
+package foo
+
+var MyName string = "vinicius"


### PR DESCRIPTION
- Implement a simple CLI-based guessing game.
- Generate a random number between 1 and 100 using the  package.
- Allow the user up to 10 attempts to guess the number.
- Provide feedback for each guess (too low, too high, or correct).
- Store and display all user attempts at the end of the game.
- Handle invalid inputs gracefully by prompting the user to enter a valid number.